### PR TITLE
Fix unused param warning

### DIFF
--- a/src/Semver200_modifier.cpp
+++ b/src/Semver200_modifier.cpp
@@ -50,7 +50,7 @@ namespace version {
 		return Version_data{ s.major, s.minor, s.patch, s.prerelease_ids, b };
 	}
 
-	Version_data Semver200_modifier::reset_major(const Version_data& s, const int m) const {
+	Version_data Semver200_modifier::reset_major(const Version_data& /*s*/, const int m) const {
 		if (m < 0) throw Modification_error("major version cannot be less than 0");
 		return Version_data{ m, 0, 0, Prerelease_identifiers{}, Build_identifiers{} };
 	}


### PR DESCRIPTION
Fixes
```
/home/gerry/dev/TMP/semver/src/Semver200_modifier.cpp: In member function ‘version::Version_data version::Semver200_modifier::reset_major(const version::Version_data&, int) const’:
/home/gerry/dev/TMP/semver/src/Semver200_modifier.cpp:53:67: error: unused parameter ‘s’ [-Werror=unused-parameter]
  Version_data Semver200_modifier::reset_major(const Version_data& s, const int m) const {
                                                                   ^
cc1plus: all warnings being treated as errors
```